### PR TITLE
Change root route formatting to fix heroku issue

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  get '/', to: 'welcome#index'
+  root to: 'welcome#index'
 
   resources :users, only: %i[show create]
   get 'register' => 'users#new'


### PR DESCRIPTION
# Description

Changed the root route from `get '/', to: 'welcome#index'` to `root to: 'welcome#index'` to fix routing issues in heroku.

Fixes # (Heroku Routing)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] RSpec
- [ ] Postman

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# Reviewed By:

- [ ] Zachary Prince
- [X] Chris Kjolhede


# Change Approval:

- [X] All changes have been verified
- [ ] Changes are required (see comments)
